### PR TITLE
Fix `uuid` to work for React Native (with no debugging)

### DIFF
--- a/Models/Queue.js
+++ b/Models/Queue.js
@@ -7,8 +7,7 @@
  */
 
 import Database from '../config/Database';
-// import uuid from 'react-native-uuid';
-import { v4 as uuidv4 } from 'uuid';
+import uuid from 'react-native-uuid';
 import Worker from './Worker';
 import promiseReflect from 'promise-reflect';
 
@@ -96,7 +95,7 @@ export class Queue {
     this.realm.write(() => {
 
       this.realm.create('Job', {
-        id: uuidv4(),
+        id: uuid.v4(),
         name,
         payload: JSON.stringify(payload),
         data: JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-queue",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A React Native Job Queue",
   "main": "index.js",
   "scripts": {
@@ -28,8 +28,7 @@
   "dependencies": {
     "promise-reflect": "^1.1.0",
     "react-native-uuid": "^1.4.9",
-    "realm": "^10.2.0",
-    "uuid": "^8.3.2"
+    "realm": "^10.2.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
@@ -43,7 +42,6 @@
     "coveralls": "^3.1.0",
     "eslint": "^7.22.0",
     "jest": "^26.6.3",
-    "should": "^13.2.3",
-    "yarn-upgrade-all": "^0.5.4"
+    "should": "^13.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,7 +2180,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -2297,11 +2297,6 @@ command-line-args@^4.0.6:
     array-back "^2.0.0"
     find-replace "^1.0.3"
     typical "^2.6.1"
-
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -5948,7 +5943,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -6141,11 +6136,3 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yarn-upgrade-all@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/yarn-upgrade-all/-/yarn-upgrade-all-0.5.4.tgz#3c00677957739187a30a4ee4824c46f43996c173"
-  integrity sha512-XaFO3Yv6cXEBizancbRxJT3fdgHfiESNJoV/czWzXRXN2CZBk61IQIFbmeMRE6HhXcBGd+rVmnUg5Csw4axdDA==
-  dependencies:
-    chalk "^4.1.0"
-    commander "^5.1.0"


### PR DESCRIPTION
The `uuid` lirary needed a `react-native-randombytes` polyfill to work on React Native (in debug mode it works without it).
`react-native-uuid` was recently updated, probably fixing the original reason to replace it.